### PR TITLE
remove installation of cmlapi

### DIFF
--- a/CMLAPI.ipynb
+++ b/CMLAPI.ipynb
@@ -19,30 +19,6 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "cluster = os.getenv(\"CDSW_DOMAIN\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# If you are not on a TLS enabled cluster (your cluster url starts with ‘http’),\n",
-    "# please use the following command instead.\n",
-    "# !pip3 install http://{cluster}/api/v2/python.tar.gz\n",
-    "!pip3 install https://{cluster}/api/v2/python.tar.gz"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
     "from cmlapi.utils import Cursor\n",
     "import cmlapi\n",
     "import string\n",


### PR DESCRIPTION
APIV2 python SDK is present by default, so there is no need to do the installation of cmlapi in AMP.