### PR TITLE
Upgrade AMP to Python 3.9

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -2,16 +2,10 @@ name: Interacting with CML using API
 description: Demonstrating examples of using API.
 author: Cloudera Inc.
 specification_version: 1.0
-prototype_version: 1.0
-date: "2021-08-10"
-api_version: 1
+prototype_version: 2.0
+date: "2022-04-05"
 
 runtimes:
   - editor: JupyterLab
-    kernel: Python 3.6
+    kernel: Python 3.9
     edition: Standard
-
-engine_images:
-  - image_name: engine
-    tags:
-      - 14

--- a/CMLAPI.ipynb
+++ b/CMLAPI.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "4077dfa7",
    "metadata": {},
    "source": [
     "# CML API Example Notebook\n",
@@ -14,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "547cf050",
    "metadata": {
     "tags": []
    },
@@ -42,6 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d1f945f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,6 +54,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "46488a86",
    "metadata": {},
    "source": [
     "## Note\n",
@@ -66,6 +70,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "83fdd6bb",
    "metadata": {},
    "source": [
     "## Create Project\n",
@@ -88,13 +93,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0ddf187d",
    "metadata": {},
    "outputs": [],
    "source": [
     "body = cmlapi.CreateProjectRequest(\n",
     "    name = \"demo_\"+session_id,\n",
     "    description = \"A demo project created using the CML public API\",\n",
-    "    default_project_engine_type = \"legacy_engine\",\n",
+    "    default_project_engine_type = \"ml_runtime\",\n",
     "    template = \"Python\")\n",
     "# Create the project\n",
     "project = client.create_project(body)\n",
@@ -104,6 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c1d6b264",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,6 +119,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9fd22cd6",
    "metadata": {},
    "source": [
     "<a id='list_projects'></a>\n",
@@ -130,6 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e5dd7228",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,6 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4eae8661",
    "metadata": {
     "scrolled": true
    },
@@ -176,6 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "77c8be77",
    "metadata": {
     "scrolled": true
    },
@@ -187,6 +198,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7bcb11db",
    "metadata": {},
    "source": [
     "## Update project\n",
@@ -205,6 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "942bcf1b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,6 +230,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fc360f35",
    "metadata": {},
    "source": [
     "## List Runtimes\n",
@@ -234,20 +248,37 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2bee6fd0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.list_runtimes()\n",
+    "client.list_runtimes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1277c543-de53-4e8b-866d-62dc682499a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# filter on Standard edition Python 3.9 runtimes using the Workbench editor\n",
+    "py39_standard_runtimes = client.list_runtimes(search_filter=json.dumps({\n",
+    "     \"kernel\": \"Python 3.9\",\n",
+    "     \"edition\": \"Standard\",\n",
+    "    \"editor\" : \"Workbench\"\n",
+    "}))\n",
     "\n",
-    "# Uncomment the following lines to filter on Python runtimes with GPUs\n",
-    "# client.list_runtimes(search_filter=json.dumps({\n",
-    "#     \"kernel\": \"Python\",\n",
-    "#     \"edition\": \"Nvidia GPU\"\n",
-    "# }))"
+    "print(py39_standard_runtimes)\n",
+    "\n",
+    "# save image identifier for later\n",
+    "py39_standard_runtime_image_identifier = py39_standard_runtimes.runtimes[0].image_identifier\n",
+    "print(\"Image identifier of the selected Python 3.9 Standard runtime: \", py39_standard_runtime_image_identifier)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f92f0bbe",
    "metadata": {},
    "source": [
     "## Cursor helper\n",
@@ -259,6 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "00d1a50c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,6 +305,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aecf6603",
    "metadata": {},
    "source": [
     "## Create Job\n",
@@ -300,6 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "514b8cdb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +342,7 @@
     "    project_id = project_id,\n",
     "    name = \"grandparentJob\",\n",
     "    script = \"analysis.py\",\n",
-    "    kernel = \"python3\",\n",
+    "    runtime_identifier = py39_standard_runtime_image_identifier,\n",
     ")\n",
     "# Create this job within the project specified by the project_id parameter.\n",
     "grandparent_job = client.create_job(grandparent_job_body, project_id)"
@@ -316,6 +350,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "025c9c0d",
    "metadata": {},
    "source": [
     "### Create dependent jobs\n",
@@ -325,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e4040728",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +369,7 @@
     "    project_id = project_id,\n",
     "    name = \"parentJob\",\n",
     "    script = \"analysis.py\",\n",
-    "    kernel = \"python3\",\n",
+    "    runtime_identifier = py39_standard_runtime_image_identifier,\n",
     "    parent_job_id = grandparent_job.id\n",
     ")\n",
     "parent_job = client.create_job(parent_job_body, project_id)"
@@ -342,6 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f873c264",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +387,7 @@
     "    project_id = project_id,\n",
     "    name = \"childJob\",\n",
     "    script = \"entry.py\",\n",
-    "    kernel = \"python3\",\n",
+    "    runtime_identifier = py39_standard_runtime_image_identifier,\n",
     "    parent_job_id = parent_job.id\n",
     ")\n",
     "child_job = client.create_job(child_job_body, project_id)"
@@ -358,6 +395,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c790db32",
    "metadata": {},
    "source": [
     "## List/Get Job"
@@ -366,6 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "62217234",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,6 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "51e7db13",
    "metadata": {
     "scrolled": true
    },
@@ -389,6 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4c51a4ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,6 +443,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d07ca0e8",
    "metadata": {},
    "source": [
     "## Update Job\n",
@@ -423,6 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a9681836",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,6 +475,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "928b5f98",
    "metadata": {},
    "source": [
     "## Create JobRun\n",
@@ -448,6 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d802f858",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,6 +507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7b5df971",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,6 +516,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1690a116",
    "metadata": {},
    "source": [
     "## List/Get JobRun\n",
@@ -479,6 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "30f83dcb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,6 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3f76cca1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,6 +547,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e4085ce2",
    "metadata": {},
    "source": [
     "## Stop JobRun"
@@ -506,6 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f0098afe",
    "metadata": {
     "scrolled": true
    },
@@ -526,6 +577,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "819c3c07",
    "metadata": {},
    "source": [
     "## Create Application\n",
@@ -551,6 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7af13279",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,7 +613,7 @@
     "    description = \"A sample application to demonstrate CML APIs\",\n",
     "    project_id = project_id,\n",
     "    subdomain = \"demo-\"+session_id,\n",
-    "    kernel = \"python3\",\n",
+    "    runtime_identifier = py39_standard_runtime_image_identifier,\n",
     "    script = \"entry.py\",\n",
     ")\n",
     "app = client.create_application(\n",
@@ -571,6 +624,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "25bd184e",
    "metadata": {},
    "source": [
     "## List/Get Applications"
@@ -578,6 +632,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "54bfe209",
    "metadata": {},
    "source": [
     "Applications can be listed using the same mechanisms (sort, search_filter, page_size, etc.) as the other resources we've seen so far. Applications can be filtered on the following properties:\n",
@@ -611,6 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "695e455b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,6 +676,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ae1a83b3",
    "metadata": {},
    "source": [
     "## Update Application\n",
@@ -642,6 +699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0b3667db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -661,6 +719,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "77b70128",
    "metadata": {},
    "source": [
     "## Model\n",
@@ -711,6 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ae491d8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,6 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f2a09bab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -734,7 +795,7 @@
     "    comment = \"test comment\",\n",
     "    file_path = \"pi.py\",\n",
     "    function_name = \"predict\",\n",
-    "    kernel = \"python3\",\n",
+    "    runtime_identifier = py39_standard_runtime_image_identifier,\n",
     ")\n",
     "modelBuild = client.create_model_build(\n",
     "    model_build_request, project_id, model.id\n",
@@ -744,6 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f670f5a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,6 +824,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b9163b2e",
    "metadata": {},
    "source": [
     "## Get/List models"
@@ -770,6 +833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "77016148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,6 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ee5bfbc4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,6 +852,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "09e5fd50",
    "metadata": {},
    "source": [
     "## Get/List model_builds"
@@ -795,6 +861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e39336ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,6 +875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9a87b7ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -816,6 +884,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "13282600",
    "metadata": {},
    "source": [
     "## Get/List model_deployments\n"
@@ -824,6 +893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "da75a3bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,6 +903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e12276d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,6 +916,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3b5869c3",
    "metadata": {},
    "source": [
     "## Stop model deployment"
@@ -853,6 +925,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c6c2c0c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -866,6 +939,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82e9809a",
    "metadata": {},
    "source": [
     "## Deleting resources"
@@ -874,6 +948,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d798a84c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,6 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "61d91679",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -893,6 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2374a247",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,6 +979,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8c2cd56f",
    "metadata": {},
    "source": [
     "**_If this documentation includes code, including but not limited to, code examples, Cloudera makes this available to you under the terms of the Apache License, Version 2.0, including any required notices. A copy of the Apache License Version 2.0 can be found in LICENSE.txt of this repository._**"
@@ -910,9 +988,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.0 64-bit",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python39064bit53fbb548e13049dda97facc40ab9ddcb"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -924,7 +1002,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0-final"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Also changes API examples to create runtime based workloads / projects instead of legacy engine based ones.
https://jira.cloudera.com/browse/DSE-20689